### PR TITLE
Add initial support for keyboard modifier (and desktop support)

### DIFF
--- a/lib/scroll-through-time.js
+++ b/lib/scroll-through-time.js
@@ -2,6 +2,17 @@
 
 import { CompositeDisposable } from 'atom';
 
+function isDescendantOfType(parentType, child) {
+     var node = child.parentNode;
+     while (node != null) {
+         if (node.localName == parentType) {
+             return true;
+         }
+         node = node.parentNode;
+     }
+     return false;
+}
+
 function getListener (options) {
   let mainAxis = options.direction == 'left' || options.direction == 'right' ? 'X' : 'Y'
   let crossAxis = mainAxis == 'X' ? 'Y' : 'X'
@@ -10,18 +21,6 @@ function getListener (options) {
   let previousScroll = 0
   let timeout
   return function (e) {
-
-      function isDescendantOfType(parentType, child) {
-           var node = child.parentNode;
-           while (node != null) {
-               if (node.localName == parentType) {
-                   return true;
-               }
-               node = node.parentNode;
-           }
-           return false;
-      }
-
     if (keyboard == null || keyboard == 'none') {
       if (Math.abs(e['delta' + mainAxis]) < Math.abs(e['delta' + crossAxis]) || !isDescendantOfType('atom-text-editor', e.target)) {
           return
@@ -66,7 +65,7 @@ export default {
       title: 'Scroll direction',
       description: 'Set the scroll direction action. Must be up/down on devices without touchpad or sidescroll.',
       type: 'string',
-      default: 'down',
+      default: 'left',
       enum: [
         {value: 'left', description: 'Scroll left to undo, right to redo'},
         {value: 'right', description: 'Scroll right to undo, left to redo'},

--- a/lib/scroll-through-time.js
+++ b/lib/scroll-through-time.js
@@ -19,6 +19,7 @@ function getListener (options) {
         return
       }
     }
+    e.stopImmediatePropagation();
     previousScroll += e['delta' + mainAxis]
     clearTimeout(timeout)
     timeout = setTimeout(() => previousScroll = 0, 50)
@@ -118,7 +119,7 @@ export default {
     window.addEventListener(
       'mousewheel',
       this.listener,
-      {passive: true}
+      {passive: false, capture: true}
     )
   },
 

--- a/lib/scroll-through-time.js
+++ b/lib/scroll-through-time.js
@@ -10,15 +10,28 @@ function getListener (options) {
   let previousScroll = 0
   let timeout
   return function (e) {
-    if (keyboard) {
-      if (Math.abs(e['delta' + mainAxis]) < Math.abs(e['delta' + crossAxis]) || !(e.altKey)) {
-        return
+
+      function isDescendantOfType(parentType, child) {
+           var node = child.parentNode;
+           while (node != null) {
+               if (node.localName == parentType) {
+                   return true;
+               }
+               node = node.parentNode;
+           }
+           return false;
+      }
+
+    if (keyboard == null || keyboard == 'none') {
+      if (Math.abs(e['delta' + mainAxis]) < Math.abs(e['delta' + crossAxis]) || !isDescendantOfType('atom-text-editor', e.target)) {
+          return
       }
     } else {
-      if (Math.abs(e['delta' + mainAxis]) < Math.abs(e['delta' + crossAxis])) {
+      if (Math.abs(e['delta' + mainAxis]) < Math.abs(e['delta' + crossAxis]) || !(e[keyboard]) || !isDescendantOfType('atom-text-editor', e.target)) {
         return
       }
     }
+    e.preventDefault();
     e.stopImmediatePropagation();
     previousScroll += e['delta' + mainAxis]
     clearTimeout(timeout)
@@ -43,9 +56,9 @@ function getListener (options) {
 export default {
 
   config: {
-    active: {
-      title: 'Scroll History Active',
-      description: 'Enable on Atom startup.',
+    autoToggle: {
+      title: 'Auto Toggle',
+      description: 'Enabled on Atom startup.',
       type: 'boolean',
       default: true
     },
@@ -61,24 +74,24 @@ export default {
         {value: 'down', description: 'Scroll down to undo, up to redo'},
       ],
     },
-    keyboardState: {
-      title: 'Keyboard + Mouse Support',
+    modifierKey: {
+      title: 'Keyboard Modifier',
       description: 'Enable support for a keyboard modifier key + scroll.',
-      type: 'boolean',
-      default: false
+      type: 'string',
+      default: 'none',
+      enum: [
+        {value: 'none', description: 'No modifier key used.'},
+        {value: 'altKey', description: 'Alt key'},
+        {value: 'ctrlKey', description: 'Control key'},
+      ],
     }
   },
   subscriptions: null,
   listener: null,
-  listenerKeyboard: null,
+  active: false,
 
   activate(state) {
     this.subscriptions = new CompositeDisposable();
-    this.listener = getListener({direction: state.direction, keyboard: state.keyboardState})
-
-    if (this.getConfig('active') || state.active) {
-      this.setupListener()
-    }
 
     this.subscriptions.add(atom.commands.add('atom-workspace', {
       'scroll-through-time:toggle': () => this.toggle(),
@@ -89,30 +102,36 @@ export default {
     this.subscriptions.add(
       atom.config.observe('scroll-through-time.direction', (newValue) => {
         this.removeListener()
-        this.listener = getListener({direction: newValue, keyboard: this.getConfig('keyboardState')})
-        if (state.active) {
+        this.listener = getListener({direction: newValue, keyboard: this.getConfig('modifierKey')})
+        if (this.active) {
           this.setupListener()
         }
       }));
 
     this.subscriptions.add(
-      atom.config.observe('scroll-through-time.keyboardState', (newValue) => {
+      atom.config.observe('scroll-through-time.modifierKey', (newValue) => {
           this.removeListener()
           this.listener = getListener({direction: this.getConfig('direction'), keyboard: newValue})
-          if (state.active) {
+          if (this.active) {
             this.setupListener()
           }
       }));
 
+    if (this.getConfig('autoToggle') || state.active) {
+      this.toggle(true)
+    }
   },
 
   deactivate() {
+    this.active = false
     this.removeListener()
     this.subscriptions.dispose();
   },
 
   serialize() {
-    return atom.config.get('scroll-through-time');
+    return {
+      active: this.active,
+    };
   },
 
   setupListener() {

--- a/lib/scroll-through-time.js
+++ b/lib/scroll-through-time.js
@@ -2,15 +2,22 @@
 
 import { CompositeDisposable } from 'atom';
 
-function getListener (direction) {
-  let mainAxis = direction == 'left' || direction == 'right' ? 'X' : 'Y'
+function getListener (options) {
+  let mainAxis = options.direction == 'left' || options.direction == 'right' ? 'X' : 'Y'
   let crossAxis = mainAxis == 'X' ? 'Y' : 'X'
-  let reversed = direction == 'right' || direction == 'down'
+  let reversed = options.direction == 'right' || options.direction == 'down'
+  let keyboard = options.keyboard
   let previousScroll = 0
   let timeout
   return function (e) {
-    if (Math.abs(e['delta' + mainAxis]) < Math.abs(e['delta' + crossAxis]) || !(e.altKey && e.shiftKey)) {
-      return
+    if (keyboard) {
+      if (Math.abs(e['delta' + mainAxis]) < Math.abs(e['delta' + crossAxis]) || !(e.altKey)) {
+        return
+      }
+    } else {
+      if (Math.abs(e['delta' + mainAxis]) < Math.abs(e['delta' + crossAxis])) {
+        return
+      }
     }
     previousScroll += e['delta' + mainAxis]
     clearTimeout(timeout)
@@ -35,17 +42,17 @@ function getListener (direction) {
 export default {
 
   config: {
-    autoToggle: {
-      title: 'Auto Toggle',
-      description: 'Toggle on start.',
+    active: {
+      title: 'Scroll History Active',
+      description: 'Enable on Atom startup.',
       type: 'boolean',
       default: true
     },
     direction: {
       title: 'Scroll direction',
-      description: 'Set the scroll direction action for two-finger mode.',
+      description: 'Set the scroll direction action. Must be up/down on devices without touchpad or sidescroll.',
       type: 'string',
-      default: 'left',
+      default: 'down',
       enum: [
         {value: 'left', description: 'Scroll left to undo, right to redo'},
         {value: 'right', description: 'Scroll right to undo, left to redo'},
@@ -53,75 +60,58 @@ export default {
         {value: 'down', description: 'Scroll down to undo, up to redo'},
       ],
     },
-    keyboardToggle: {
-      title: 'Keyboard Modifier Support',
+    keyboardState: {
+      title: 'Keyboard + Mouse Support',
       description: 'Enable support for a keyboard modifier key + scroll.',
       type: 'boolean',
-      default: true
-    },
-    keyboardDirection: {
-      title: 'Keyboard Scroll direction',
-      description: 'Set the scroll direction action for keyboard mode.',
-      type: 'string',
-      default: 'up',
-      enum: [
-        {value: 'up', description: 'Scroll up to undo, down to redo'},
-        {value: 'down', description: 'Scroll down to undo, up to redo'},
-      ],
+      default: false
     }
   },
   subscriptions: null,
   listener: null,
   listenerKeyboard: null,
-  active: false,
-  activeKeyboard: false,
 
   activate(state) {
     this.subscriptions = new CompositeDisposable();
+    this.listener = getListener({direction: state.direction, keyboard: state.keyboardState})
+
+    if (this.getConfig('active') || state.active) {
+      this.setupListener()
+    }
 
     this.subscriptions.add(atom.commands.add('atom-workspace', {
       'scroll-through-time:toggle': () => this.toggle(),
       'scroll-through-time:enable': () => this.toggle(true),
-      'scroll-through-time:disable': () => this.toggle(false),
-      'scroll-through-time:keyboardToggle': () => this.toggleKeyboard(false)
+      'scroll-through-time:disable': () => this.toggle(false)
     }));
 
     this.subscriptions.add(
       atom.config.observe('scroll-through-time.direction', (newValue) => {
         this.removeListener()
-        this.listener = getListener(newValue)
-        this.setupListener()
+        this.listener = getListener({direction: newValue, keyboard: this.getConfig('keyboardState')})
+        if (state.active) {
+          this.setupListener()
+        }
       }));
 
     this.subscriptions.add(
-      atom.config.observe('scroll-through-time.keyboardDirection', (newValue) => {
-        this.removeKeyboardListener()
-        this.listenerKeyboard = getListener(newValue)
-        this.setupKeyboardListener()
+      atom.config.observe('scroll-through-time.keyboardState', (newValue) => {
+          this.removeListener()
+          this.listener = getListener({direction: this.getConfig('direction'), keyboard: newValue})
+          if (state.active) {
+            this.setupListener()
+          }
       }));
 
-    if (this.getConfig('autoToggle') || state.active) {
-      this.toggle(true)
-    }
-
-    if (this.getConfig('keyboardToggle') || state.activeKeyboard) {
-      this.toggleKeyboard(true)
-    }
   },
 
   deactivate() {
-    this.active = false
-    this.activeKeyboard = false
     this.removeListener()
-    this.removeKeyboardListener()
     this.subscriptions.dispose();
   },
 
   serialize() {
-    return {
-      active: this.active,
-      activeKeyboard: this.activeKeyboard
-    };
+    return atom.config.get('scroll-through-time');
   },
 
   setupListener() {
@@ -132,20 +122,8 @@ export default {
     )
   },
 
-  setupKeyboardListener() {
-    window.addEventListener(
-      'mousewheel',
-      this.listenerKeyboard,
-      {passive: true}
-    )
-  },
-
   removeListener() {
     window.removeEventListener('mousewheel', this.listener)
-  },
-
-  removeKeyboardListener() {
-    window.removeEventListener('mousewheel', this.listenerKeyboard)
   },
 
   toggle(force) {
@@ -156,17 +134,6 @@ export default {
       this.active ?
       this.setupListener() :
       this.removeListener()
-    );
-  },
-
-  toggleKeyboard(force) {
-    this.activeKeyboard = typeof force !== 'undefined'
-      ? force
-      : !this.activeKeyboard
-    return (
-      this.activeKeyboard ?
-      this.setupKeyboardListener() :
-      this.removeKeyboardListener()
     );
   },
 

--- a/lib/scroll-through-time.js
+++ b/lib/scroll-through-time.js
@@ -9,7 +9,7 @@ function getListener (direction) {
   let previousScroll = 0
   let timeout
   return function (e) {
-    if (Math.abs(e['delta' + mainAxis]) < Math.abs(e['delta' + crossAxis])) {
+    if (Math.abs(e['delta' + mainAxis]) < Math.abs(e['delta' + crossAxis]) || !(e.altKey && e.shiftKey)) {
       return
     }
     previousScroll += e['delta' + mainAxis]
@@ -43,6 +43,7 @@ export default {
     },
     direction: {
       title: 'Scroll direction',
+      description: 'Set the scroll direction action for two-finger mode.',
       type: 'string',
       default: 'left',
       enum: [
@@ -51,11 +52,29 @@ export default {
         {value: 'up', description: 'Scroll up to undo, down to redo'},
         {value: 'down', description: 'Scroll down to undo, up to redo'},
       ],
+    },
+    keyboardToggle: {
+      title: 'Keyboard Modifier Support',
+      description: 'Enable support for a keyboard modifier key + scroll.',
+      type: 'boolean',
+      default: true
+    },
+    keyboardDirection: {
+      title: 'Keyboard Scroll direction',
+      description: 'Set the scroll direction action for keyboard mode.',
+      type: 'string',
+      default: 'up',
+      enum: [
+        {value: 'up', description: 'Scroll up to undo, down to redo'},
+        {value: 'down', description: 'Scroll down to undo, up to redo'},
+      ],
     }
   },
   subscriptions: null,
   listener: null,
+  listenerKeyboard: null,
   active: false,
+  activeKeyboard: false,
 
   activate(state) {
     this.subscriptions = new CompositeDisposable();
@@ -63,7 +82,8 @@ export default {
     this.subscriptions.add(atom.commands.add('atom-workspace', {
       'scroll-through-time:toggle': () => this.toggle(),
       'scroll-through-time:enable': () => this.toggle(true),
-      'scroll-through-time:disable': () => this.toggle(false)
+      'scroll-through-time:disable': () => this.toggle(false),
+      'scroll-through-time:keyboardToggle': () => this.toggleKeyboard(false)
     }));
 
     this.subscriptions.add(
@@ -73,20 +93,34 @@ export default {
         this.setupListener()
       }));
 
+    this.subscriptions.add(
+      atom.config.observe('scroll-through-time.keyboardDirection', (newValue) => {
+        this.removeKeyboardListener()
+        this.listenerKeyboard = getListener(newValue)
+        this.setupKeyboardListener()
+      }));
+
     if (this.getConfig('autoToggle') || state.active) {
       this.toggle(true)
+    }
+
+    if (this.getConfig('keyboardToggle') || state.activeKeyboard) {
+      this.toggleKeyboard(true)
     }
   },
 
   deactivate() {
     this.active = false
+    this.activeKeyboard = false
     this.removeListener()
+    this.removeKeyboardListener()
     this.subscriptions.dispose();
   },
 
   serialize() {
     return {
-      active: this.active
+      active: this.active,
+      activeKeyboard: this.activeKeyboard
     };
   },
 
@@ -98,8 +132,20 @@ export default {
     )
   },
 
+  setupKeyboardListener() {
+    window.addEventListener(
+      'mousewheel',
+      this.listenerKeyboard,
+      {passive: true}
+    )
+  },
+
   removeListener() {
     window.removeEventListener('mousewheel', this.listener)
+  },
+
+  removeKeyboardListener() {
+    window.removeEventListener('mousewheel', this.listenerKeyboard)
   },
 
   toggle(force) {
@@ -110,6 +156,17 @@ export default {
       this.active ?
       this.setupListener() :
       this.removeListener()
+    );
+  },
+
+  toggleKeyboard(force) {
+    this.activeKeyboard = typeof force !== 'undefined'
+      ? force
+      : !this.activeKeyboard
+    return (
+      this.activeKeyboard ?
+      this.setupKeyboardListener() :
+      this.removeKeyboardListener()
     );
   },
 


### PR DESCRIPTION
So I had read about this package for Atom somewhere and was really excited to give it a shot. However I mostly use a desktop workstation and realized it won't work here. So when I saw #4 and #11 I realized that adding support for that could probably solve my problem too.

----

With this patch it's now possible to use keyboard modifies with the mouse scroll to scroll thru time.

Currently this only supports using Ctrl+Alt+Scroll, however it can likely be adapted to use any other key modifier via config. Just my first time dabbling in Atom packages so I'm not 100% on how to do that part yet. :smile: