### PR TITLE
Add alt-text of comic to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,5 +11,7 @@ apm install scroll-through-time
 ```
 
 ## Why?
+If used with software that could keep up, a scroll wheel mapped to send a stream of 'undo' and 'redo' events could be kind of cool.
+
 ![If used with software that could keep up, a scroll wheel mapped to send a stream of 'undo' and 'redo' events could be kind of cool.](https://imgs.xkcd.com/comics/borrow_your_laptop.png)
 _ xkcd ([#1806](https://xkcd.com/1806/))


### PR DESCRIPTION
alt-text previously only appeared when the comic picture was unavailable - and didn't support mouseover.